### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 script:
   - cd algo/graph && mvn clean package


### PR DESCRIPTION
Resolves the error
```
Expected feature release number in range of 9 to 14, but got: 8

The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
```